### PR TITLE
refactor: move make_markdown_link to markdown module and update AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,12 +165,27 @@ end)
   - `lua/davewiki/init.lua` → `tests/lua/davewiki/init_spec.lua`
   - `lua/davewiki/core.lua` → `tests/lua/davewiki/core_spec.lua`
 
+## Module Dependencies
+
+**No circular dependencies between modules.** The module hierarchy must remain acyclic.
+
+```
+Level 0 (leaf):    core.lua, test_util.lua (no dependencies)
+Level 1:           tags.lua, markdown.lua, journal.lua → core
+Level 2:           cmp.lua → tags; view.lua → core, markdown, tags
+Level 3:           telescope.lua → core, markdown, tags (lazy: view, journal)
+Level 4 (root):    init.lua → cmp, core, journal, markdown, tags, telescope, view
+```
+
+All dependency paths terminate at `core.lua`. When adding new modules, maintain this layered structure.
+
 ## Code Quality
 
 - All Lua code must include **type annotations**.
 - Type checking via lua-language-server must pass.
 - Follow lua-language-server (LuaLS) naming conventions.
 - Run `luacheck` (linter) and `stylua` (formatter) before committing.
+- **Avoid useless wrapper functions.** Do not create single-line functions that just call another function directly without adding any value. Use the underlying function instead.
 
 ### Keymaps and Autocommands
 

--- a/lua/davewiki/core.lua
+++ b/lua/davewiki/core.lua
@@ -174,19 +174,4 @@ M.generate_absolute_path = function(target_file)
     return M.url_encode(relative_path)
 end
 
---- Creates a markdown link from an absolute file path
---- @param file_path string The absolute file path
---- @param title string|nil Optional title for the link (defaults to filename without extension)
---- @return string|nil Markdown link in format [title](/path), or nil if path is outside wiki_root
-M.make_markdown_link = function(file_path, title)
-    local encoded_path = M.generate_absolute_path(file_path)
-
-    if not encoded_path then
-        return nil
-    end
-
-    local link_title = title or vim.fn.fnamemodify(file_path, ":t:r")
-    return "[" .. link_title .. "](" .. encoded_path .. ")"
-end
-
 return M

--- a/lua/davewiki/markdown.lua
+++ b/lua/davewiki/markdown.lua
@@ -204,6 +204,21 @@ M.extract_h1_or_filename = function(file_path)
     return filename
 end
 
+--- Creates a markdown link from an absolute file path
+--- @param file_path string The absolute file path
+--- @param title string|nil Optional title for the link (defaults to filename without extension)
+--- @return string|nil Markdown link in format [title](/path), or nil if path is outside wiki_root
+M.make_markdown_link = function(file_path, title)
+    local encoded_path = core.generate_absolute_path(file_path)
+
+    if not encoded_path then
+        return nil
+    end
+
+    local link_title = title or vim.fn.fnamemodify(file_path, ":t:r")
+    return "[" .. link_title .. "](" .. encoded_path .. ")"
+end
+
 --- Get a sorted list of all level-1 headings from the wiki
 --- Uses ripgrep to find lines starting with "# " (but not "##")
 ---@return table Array of heading objects with text, file, and lnum fields

--- a/lua/davewiki/telescope.lua
+++ b/lua/davewiki/telescope.lua
@@ -10,6 +10,8 @@ local markdown = require("davewiki.markdown")
 local tags = require("davewiki.tags")
 
 ---@class DavewikiTelescopeConfig
+
+---@class DavewikiTelescopeConfig
 ---@field enabled boolean Enable telescope integration
 
 telescope.config = {
@@ -289,7 +291,8 @@ function telescope.insert_link()
                     require("telescope.actions").close(bufnr)
 
                     if selection then
-                        local link_text = core.make_markdown_link(selection.filename, selection.title)
+                        local link_text =
+                            markdown.make_markdown_link(selection.filename, selection.title)
 
                         if link_text then
                             vim.api.nvim_put({ link_text }, "c", true, true)

--- a/lua/davewiki/view.lua
+++ b/lua/davewiki/view.lua
@@ -14,6 +14,7 @@
 local M = {}
 
 local core = require("davewiki.core")
+local markdown = require("davewiki.markdown")
 local tags = require("davewiki.tags")
 
 --- @class TagMention
@@ -171,7 +172,7 @@ function M.extract_journal_blocks_from_mention(tag_name, mention)
     for _, block_content in ipairs(file_blocks) do
         if block_content:find(tag_name, 1, true) then
             local filename = vim.fn.fnamemodify(mention.file, ":t:r")
-            local link = core.make_markdown_link(mention.file, filename)
+            local link = markdown.make_markdown_link(mention.file, filename)
             table.insert(blocks, {
                 link = link,
                 content = block_content,
@@ -195,7 +196,7 @@ function M.extract_wiki_paragraphs_from_mention(tag_name, mention)
 
     for _, para in ipairs(found_paras) do
         local filename = vim.fn.fnamemodify(mention.file, ":t:r")
-        local link = core.make_markdown_link(mention.file, filename)
+        local link = markdown.make_markdown_link(mention.file, filename)
         table.insert(paragraphs, {
             link = link,
             content = para,
@@ -230,7 +231,7 @@ function M.extract_journal_blocks(tag_name, mentions)
             for _, block_content in ipairs(file_blocks) do
                 if block_content:find(tag_name, 1, true) then
                     local filename = vim.fn.fnamemodify(mention.file, ":t:r")
-                    local link = core.make_markdown_link(mention.file, filename)
+                    local link = markdown.make_markdown_link(mention.file, filename)
                     table.insert(blocks, {
                         link = link,
                         content = block_content,
@@ -267,7 +268,7 @@ function M.extract_wiki_paragraphs(tag_name, mentions)
 
             for _, para in ipairs(found_paras) do
                 local filename = vim.fn.fnamemodify(mention.file, ":t:r")
-                local link = core.make_markdown_link(mention.file, filename)
+                local link = markdown.make_markdown_link(mention.file, filename)
                 table.insert(paragraphs, {
                     link = link,
                     content = para,

--- a/tests/lua/davewiki/core_spec.lua
+++ b/tests/lua/davewiki/core_spec.lua
@@ -221,39 +221,3 @@ describe("davewiki.core generate_absolute_path", function()
         assert.is_nil(result)
     end)
 end)
-
-describe("davewiki.core make_markdown_link", function()
-    before_each(function()
-        core.wiki_root = test_root
-    end)
-
-    after_each(function()
-        core.wiki_root = nil
-    end)
-
-    it("should create markdown link for file within wiki_root", function()
-        local result = core.make_markdown_link(test_root .. "/notes/file.md")
-        assert.are.equal("[file](/notes/file.md)", result)
-    end)
-
-    it("should use custom title when provided", function()
-        local result = core.make_markdown_link(test_root .. "/notes/file.md", "My Title")
-        assert.are.equal("[My Title](/notes/file.md)", result)
-    end)
-
-    it("should handle files with spaces in names", function()
-        local result = core.make_markdown_link(test_root .. "/notes/my file.md")
-        assert.are.equal("[my file](/notes/my%20file.md)", result)
-    end)
-
-    it("should return nil for file outside wiki_root", function()
-        local result = core.make_markdown_link("/etc/passwd")
-        assert.is_nil(result)
-    end)
-
-    it("should return nil when wiki_root is nil", function()
-        core.wiki_root = nil
-        local result = core.make_markdown_link("/any/path")
-        assert.is_nil(result)
-    end)
-end)

--- a/tests/lua/davewiki/markdown_spec.lua
+++ b/tests/lua/davewiki/markdown_spec.lua
@@ -133,7 +133,8 @@ describe("davewiki.markdown get_link_under_cursor", function()
     it("should handle multiple links on same line", function()
         local buf = vim.api.nvim_create_buf(false, true)
         vim.api.nvim_buf_set_lines(
-            buf,0,
+            buf,
+            0,
             -1,
             false,
             { "Text [first](a.md) and [second](b.md) here" }
@@ -312,7 +313,10 @@ describe("davewiki.markdown jump_to_link", function()
         local result = markdown.jump_to_link()
         assert.is_false(result)
         assert.are.equal(1, #mock_notify.calls)
-        assert.are.equal("davewiki: file not found: " .. test_root .. "/nonexistent.md", mock_notify.calls[1].msg)
+        assert.are.equal(
+            "davewiki: file not found: " .. test_root .. "/nonexistent.md",
+            mock_notify.calls[1].msg
+        )
         assert.are.equal(vim.log.levels.WARN, mock_notify.calls[1].level)
 
         vim.api.nvim_buf_delete(buf, { force = true })
@@ -389,7 +393,10 @@ describe("davewiki.markdown jump_to_link", function()
         local result = markdown.jump_to_link()
         assert.is_false(result)
         assert.are.equal(1, #mock_notify.calls)
-        assert.are.equal("davewiki: Only .md files are supported for internal links", mock_notify.calls[1].msg)
+        assert.are.equal(
+            "davewiki: Only .md files are supported for internal links",
+            mock_notify.calls[1].msg
+        )
         assert.are.equal(vim.log.levels.WARN, mock_notify.calls[1].level)
 
         vim.api.nvim_buf_delete(buf, { force = true })
@@ -415,7 +422,7 @@ describe("davewiki.markdown get_headings_list", function()
     it("should sort headings alphabetically", function()
         local headings = markdown.get_headings_list()
         for i = 2, #headings do
-            assert.is_true(headings[i -1].text <= headings[i].text)
+            assert.is_true(headings[i - 1].text <= headings[i].text)
         end
     end)
 
@@ -424,5 +431,41 @@ describe("davewiki.markdown get_headings_list", function()
         local headings = markdown.get_headings_list()
         assert.is_table(headings)
         assert.are.equal(0, #headings)
+    end)
+end)
+
+describe("davewiki.markdown make_markdown_link", function()
+    before_each(function()
+        core.wiki_root = test_root
+    end)
+
+    after_each(function()
+        core.wiki_root = nil
+    end)
+
+    it("should create markdown link for file within wiki_root", function()
+        local result = markdown.make_markdown_link(test_root .. "/notes/file.md")
+        assert.are.equal("[file](/notes/file.md)", result)
+    end)
+
+    it("should use custom title when provided", function()
+        local result = markdown.make_markdown_link(test_root .. "/notes/file.md", "My Title")
+        assert.are.equal("[My Title](/notes/file.md)", result)
+    end)
+
+    it("should handle files with spaces in names", function()
+        local result = markdown.make_markdown_link(test_root .. "/notes/my file.md")
+        assert.are.equal("[my file](/notes/my%20file.md)", result)
+    end)
+
+    it("should return nil for file outside wiki_root", function()
+        local result = markdown.make_markdown_link("/etc/passwd")
+        assert.is_nil(result)
+    end)
+
+    it("should return nil when wiki_root is nil", function()
+        core.wiki_root = nil
+        local result = markdown.make_markdown_link("/any/path")
+        assert.is_nil(result)
     end)
 end)


### PR DESCRIPTION
## Summary
- Move `make_markdown_link` function from `core.lua` to `markdown.lua` where it logically belongs
- Update all callers (`telescope.lua`, `view.lua`) to use `markdown.make_markdown_link`
- Move corresponding tests from `core_spec.lua` to `markdown_spec.lua`
- Add module dependency graph to AGENTS.md showing the acyclic module hierarchy
- Add code quality rules: no circular dependencies, avoid useless wrapper functions