### PR TITLE
fix(cmp): only enable tag completion within wiki_root

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,33 @@
+# markdownlint (mdl) configuration for davewiki2 project
+# Place this file at .mdlrc in the project root
+
+# Rule configuration
+# See: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md
+
+# MD013 - Line length
+# Exclude - many lines are intentionally long (commands, code, URLs)
+exclude_rule 'MD013'
+
+# MD029 - Ordered list item prefix
+# Allow using '1.' for all items (this is valid markdown and makes reordering easier)
+rule 'MD029', :style => :ordered
+
+# MD007 - Unordered list indentation
+# Use 2-space indentation for lists to match common style
+rule 'MD007', :indent => 2
+
+# MD033 - Inline HTML
+# Allow inline HTML (sometimes needed for special formatting)
+exclude_rule 'MD033'
+
+# MD041 - First line in file should be a top level header
+# Not applicable for AGENTS.md which starts with instructions
+exclude_rule 'MD041'
+
+# MD024 - Multiple headers with the same content
+# Allow duplicate headers (common in long documents)
+exclude_rule 'MD024'
+
+# MD034 - Bare URL used
+# Allow bare URLs (they render fine in most markdown parsers)
+exclude_rule 'MD034'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md
 
-Instructions for AI coding assistants working on this project. Read `PROJECT_PLAN.md` for full project context.
+Instructions for AI coding assistants working on this project. Read `PROJECT_PLAN.md` for full
+project context.
 
 ## Git Commits
 
@@ -24,26 +25,32 @@ Follow test-driven development:
 To run the complete test suite:
 
 ```sh
-nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c 'PlenaryBustedDirectory tests' -c 'qa!'
+nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c \
+  'PlenaryBustedDirectory tests' -c 'qa!'
 ```
 
 Or run individual test files:
 
 ```sh
 # Run core module tests
-nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c 'PlenaryBustedFile tests/lua/davewiki/core_spec.lua' -c 'qa!'
+nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c \
+  'PlenaryBustedFile tests/lua/davewiki/core_spec.lua' -c 'qa!'
 
 # Run tags module tests
-nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c 'PlenaryBustedFile tests/lua/davewiki/tags_spec.lua' -c 'qa!'
+nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c \
+  'PlenaryBustedFile tests/lua/davewiki/tags_spec.lua' -c 'qa!'
 
 # Run markdown module tests
-nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c 'PlenaryBustedFile tests/lua/davewiki/markdown_spec.lua' -c 'qa!'
+nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c \
+  'PlenaryBustedFile tests/lua/davewiki/markdown_spec.lua' -c 'qa!'
 
 # Run init module tests
-nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c 'PlenaryBustedFile tests/lua/davewiki/init_spec.lua' -c 'qa!'
+nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c \
+  'PlenaryBustedFile tests/lua/davewiki/init_spec.lua' -c 'qa!'
 
 # Run cmp module tests
-nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c 'PlenaryBustedFile tests/lua/davewiki/cmp_spec.lua' -c 'qa!'
+nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c \
+  'PlenaryBustedFile tests/lua/davewiki/cmp_spec.lua' -c 'qa!'
 ```
 
 ### Test Commands Reference
@@ -56,22 +63,28 @@ nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c 'PlenaryBustedF
 
 ### Current Test Suite
 
-- `tests/lua/davewiki/core_spec.lua` - Core module tests (wiki_root resolution, utility functions)
+- `tests/lua/davewiki/core_spec.lua` - Core module tests (wiki_root resolution, utility
+  functions)
 - `tests/lua/davewiki/tags_spec.lua` - Tags module tests (tag file management, tag operations)
-- `tests/lua/davewiki/markdown_spec.lua` - Markdown module tests (markdown links, file operations)
+- `tests/lua/davewiki/markdown_spec.lua` - Markdown module tests (markdown links, file
+  operations)
 - `tests/lua/davewiki/init_spec.lua` - Init module tests (public API)
 - `tests/lua/davewiki/cmp_spec.lua` - Cmp module tests (nvim-cmp tag completion)
-- `tests/lua/davewiki/telescope_spec.lua` - Telescope module tests (telescope.nvim integration)
-- `tests/lua/davewiki/journal_spec.lua` - Journal module tests (daily journal management, telescope journal picker)
+- `tests/lua/davewiki/telescope_spec.lua` - Telescope module tests (telescope.nvim
+  integration)
+- `tests/lua/davewiki/journal_spec.lua` - Journal module tests (daily journal management,
+  telescope journal picker)
 - `tests/lua/davewiki/view_spec.lua` - View module tests (synthetic tag view generation)
 - Total: 273 tests covering all implemented features
 
 ### Testing Rules
 
-- **Never mock** vim internal functions or filesystem operations unless there is no alternative.
+- **Never mock** vim internal functions or filesystem operations unless there is no
+  alternative.
 - Tests run against **real files** in `test_root/` — no mocking the filesystem.
 - Tests must use `test_root` as the `wiki_root` and **never access files outside it**.
-- **Tests must run with zero warnings.** If a test triggers a warning because it exercises code that calls `vim.notify`, use `MockNotify` to capture and assert the notification message.
+- **Tests must run with zero warnings.** If a test triggers a warning because it exercises code
+  that calls `vim.notify`, use `MockNotify` to capture and assert the notification message.
 
 ### Testing Warning Notifications
 
@@ -110,25 +123,32 @@ describe("module with warnings", function()
         assert.is_false(result)
         assert.are.equal(1, #mock_notify.calls)
         assert.are.equal("davewiki: expected warning message", mock_notify.calls[1].msg)
-        assert.are.equal(vim.log.levels.ERROR, mock_notify.calls[1].level)  -- or vim.log.levels.WARN
+        assert.are.equal(vim.log.levels.ERROR, mock_notify.calls[1].level)  -- or
+        -- vim.log.levels.WARN
     end)
 end)
 ```
 
-Note: Check the actual code to determine whether it uses `vim.log.levels.ERROR` (4) or `vim.log.levels.WARN` (3).
+Note: Check the actual code to determine whether it uses `vim.log.levels.ERROR` (4) or
+`vim.log.levels.WARN` (3).
 
 ### Test File Management
 
 When creating, reading, or modifying files in `test_root/` during tests:
 
 1. **Do not modify or delete** files tracked by git (e.g., existing test fixtures)
-2. **Use unique names** for each test's files to avoid collisions (e.g., `test-view-unique-*.md`, dates like `2099-01-15`)
-3. **Cleanup only files created** by that test in `after_each` — never delete all files in a directory
-4. **Create files before testing deletion** — if testing file deletion, create the file first
+2. **Use unique names** for each test's files to avoid collisions (e.g., `test-view-unique-*.md`,
+   dates like `2099-01-15`)
+3. **Cleanup only files created** by that test in `after_each` — never delete all files in
+   a directory
+4. **Create files before testing deletion** — if testing file deletion, create the file
+   first
 5. **Never add test files to git** — files created during tests should remain untracked
-6. **Tests are broken if they fail from test pollution** — each test must be isolated and not depend on state from other tests
+6. **Tests are broken if they fail from test pollution** — each test must be isolated and
+   not depend on state from other tests
 
 Example pattern for tracked cleanup:
+
 ```lua
 local created_files = {}
 
@@ -177,7 +197,8 @@ Level 3:           telescope.lua → core, markdown, tags (lazy: view, journal)
 Level 4 (root):    init.lua → cmp, core, journal, markdown, tags, telescope, view
 ```
 
-All dependency paths terminate at `core.lua`. When adding new modules, maintain this layered structure.
+All dependency paths terminate at `core.lua`. When adding new modules, maintain this
+layered structure.
 
 ## Code Quality
 
@@ -185,15 +206,19 @@ All dependency paths terminate at `core.lua`. When adding new modules, maintain 
 - Type checking via lua-language-server must pass.
 - Follow lua-language-server (LuaLS) naming conventions.
 - Run `luacheck` (linter) and `stylua` (formatter) before committing.
-- **Avoid useless wrapper functions.** Do not create single-line functions that just call another function directly without adding any value. Use the underlying function instead.
+- **Avoid useless wrapper functions.** Do not create single-line functions that just call
+  another function directly without adding any value. Use the underlying function instead.
 
 ### Keymaps and Autocommands
 
 - All keymaps must include a `desc` property describing their function.
 - All autocommands must include a `desc` property describing their function.
 - Example:
+
   ```lua
-  vim.keymap.set('n', '<leader>tw', function() require('davewiki').jump_to_tag() end, { desc = 'Jump to tag file under cursor' })
+  vim.keymap.set('n', '<leader>tw',
+    function() require('davewiki').jump_to_tag() end,
+    { desc = 'Jump to tag file under cursor' })
   vim.api.nvim_create_autocmd("BufEnter", {
     group = augroup,
     pattern = "*.md",
@@ -204,26 +229,31 @@ All dependency paths terminate at `core.lua`. When adding new modules, maintain 
 
 ### Documentation
 
-- **Lua files:** Module-level and file-level docstrings. Function docstrings with type annotations.
+- **Lua files:** Module-level and file-level docstrings. Function docstrings with
+  type annotations.
 - **Nix files:** File-level descriptions and inline comments.
 - **Tests:** Clearly describe intent — what is being tested, why, and why this approach.
 
 ## Security Rules
 
 - Use `vim.system` for **all** shell command execution.
-- **Escape/encode** all user input (tag names, file paths, search queries) when used in shell commands.
+- **Escape/encode** all user input (tag names, file paths, search queries) when used in
+  shell commands.
 - Validate tag names against `#[A-Za-z0-9-_]+` (at word boundaries).
 - URL-encode markdown hyperlink target paths.
 - The plugin must **only** access files under the configured `wiki_root`.
 
 ## Antipatterns to Avoid
 
-1. **Over-mocking in unit tests** — produces passing tests for incorrect code. Use real `test_root/` files.
-2. **Requiring third-party modules at import time** — causes unnecessary startup errors. Load third-party Lua modules just before use (at setup time, not import time).
+1. **Over-mocking in unit tests** — produces passing tests for incorrect code. Use real
+   `test_root/` files.
+2. **Requiring third-party modules at import time** — causes unnecessary startup errors.
+   Load third-party Lua modules just before use (at setup time, not import time).
 
 ## Pre-Commit Review
 
-Before committing, spawn a subagent to run a code review. The review should check for:
+Before committing, spawn a subagent to run a code review. The review should check
+for:
 
 - Correctness
 - Consistency with existing code
@@ -236,7 +266,9 @@ Before committing, spawn a subagent to run a code review. The review should chec
 
 ## Documentation Consistency
 
-Use the `documentation-consistency` skill to check that README.md, PROJECT_PLAN.md, AGENTS.md, and flake.nix are consistent with each other and with the actual project state. Run this skill when making changes that affect project structure, conventions, or features.
+Use the `documentation-consistency` skill to check that README.md, PROJECT_PLAN.md,
+AGENTS.md, and flake.nix are consistent with each other and with the actual project state.
+Run this skill when making changes that affect project structure, conventions, or features.
 
 ## Commit Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,7 @@ layered structure.
 - All Lua code must include **type annotations**.
 - Type checking via lua-language-server must pass.
 - Follow lua-language-server (LuaLS) naming conventions.
-- Run `luacheck` (linter) and `stylua` (formatter) before committing.
+- Run `luacheck` (Lua linter), `stylua` (Lua formatter), and `mdl -s mdl_style.rb` (markdown linter) before committing.
 - **Avoid useless wrapper functions.** Do not create single-line functions that just call
   another function directly without adding any value. Use the underlying function instead.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c 'PlenaryBustedF
 - `tests/lua/davewiki/telescope_spec.lua` - Telescope module tests (telescope.nvim integration)
 - `tests/lua/davewiki/journal_spec.lua` - Journal module tests (daily journal management, telescope journal picker)
 - `tests/lua/davewiki/view_spec.lua` - View module tests (synthetic tag view generation)
-- Total: 264 tests covering all implemented features
+- Total: 273 tests covering all implemented features
 
 ### Testing Rules
 

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -83,7 +83,7 @@ Command-line neovim users who want a simple journal-based note-taking system.
 - git - version control
 - ripgrep - search utility
 - fd - file finder
-- lz.n - lazy loading support (optional for users)
+- gh - GitHub CLI
 - plenary.nvim tests - testing framework
 
 **CI/CD:**
@@ -106,9 +106,10 @@ Command-line neovim users who want a simple journal-based note-taking system.
    - `davewiki/cmp.lua` - nvim-cmp integration
    - `davewiki/telescope.lua` - Telescope integration for tag and heading search
    - `davewiki/journal.lua` - Daily journal management and navigation
-   - `davewiki/view.lua` - Synthetic tag view generation
-
-2. **Tests:**
+    - `davewiki/view.lua` - Synthetic tag view generation
+    - `davewiki/test_util.lua` - Testing utilities (MockNotify)
+ 
+ 2. **Tests:**
    - `tests/` - plenary.nvim test suite
    - `test_root/` directory - sample notes and tags for testing
 
@@ -137,7 +138,6 @@ README.md
 PROJECT_PLAN.md
 AGENTS.md
 flake.nix                (nix build configuration)
-feature-plans/           (feature specification documents)
 ```
 
 **Wiki Directory Structure (managed by plugin for users):**

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -7,6 +7,7 @@
 ---
 
 ## Table of Contents
+
 1. [Overview](#1-overview)
 2. [Tech Stack](#2-tech-stack)
 3. [Architecture Overview](#3-architecture-overview)
@@ -19,64 +20,83 @@
 ## 1. Overview
 
 **What it is:**
-A neovim plugin implementing a personal knowledge base system with journal-based note-taking, similar to Logseq. It focuses on simplicity and command-line workflow for neovim users.
+
+A neovim plugin implementing a personal knowledge base system with
+journal-based note-taking, similar to Logseq. It focuses on simplicity and
+command-line workflow for neovim users.
 
 **Primary users/stakeholders:**
+
 Command-line neovim users who want a simple journal-based note-taking system.
 
 **Scope (IN):**
+
 - Manages a directory of markdown-based note files and daily journals
-- Manages "tags" (`#tag-name`) backed by flat files in the `sources/` directory, supporting search, jump-to-tag, and back-reference finding
+- Manages "tags" (`#tag-name`) backed by flat files in the `sources/`
+  directory, supporting search, jump-to-tag, and back-reference finding
 - Markdown editing convenience features:
   - Jump to file for tag under cursor
   - Jump to target of markdown link under cursor
   - Auto-complete tags with nvim-cmp
   - Generate synthetic tag views aggregating all references to a tag
+
 - Search for tags, headings, etc. across all files
 - Integration with nvim-cmp and telescope.nvim
 
 **Scope (OUT):**
+
 - This is NOT a markdown LSP
 - No HTML export/generation of documents
 
 **Key context/constraints:**
-- **Scale:** Small scale (tens to hundreds of notes) - personal use case
-- **Tag format:** Flat tags (not hierarchical), stored as files under `sources/` directory within the `wiki_root`
-- **Back-references:** Search-based reference finding (not full backlink tracking)
+
+- **Scale:** Small scale (tens to hundreds of notes) - personal use
+  case
+- **Tag format:** Flat tags (not hierarchical), stored as files under
+  `sources/` directory within the `wiki_root`
+- **Back-references:** Search-based reference finding (not full backlink
+  tracking)
 
 ---
 
 ## 2. Tech Stack
 
 **Languages:**
+
 - Lua (LuaJIT bundled with neovim)
 - Nix (for build/packaging and dev shell)
 
 **Frameworks & Libraries:**
 
 **Required:**
+
 - Neovim 0.9+ - target platform
 - nvim-cmp - tag auto-completion
 - telescope.nvim - search UI
 - plenary.nvim - testing utilities
 
 **Optional:**
+
 - cmp-buffer - buffer word completion source
 - telescope-fzf-native - FZF sorter for telescope
 - vim-markdown - Markdown syntax and ftplugin
 - which-key.nvim - keybinding help/discovery
 
 **Build Tools:**
+
 - Nix flakes - build, packaging, and reproducibility
 - Nix dev shell - development environment
 
 **Databases & Storage:**
+
 - Filesystem only - notes stored as plain markdown files
 
 **External Services:**
+
 - None
 
 **Development Tools:**
+
 - luacheck - linting
 - stylua - Lua formatter
 - lua-language-server - type checking
@@ -87,9 +107,11 @@ Command-line neovim users who want a simple journal-based note-taking system.
 - plenary.nvim tests - testing framework
 
 **CI/CD:**
+
 - None planned
 
 **Versioning:**
+
 - Semantic Versioning (Semver)
 
 ---
@@ -99,26 +121,31 @@ Command-line neovim users who want a simple journal-based note-taking system.
 **System Components:**
 
 1. **Lua Modules (in `lua/` directory):**
-   - `davewiki/init.lua` - Public interface, provides `setup()` function
-   - `davewiki/core.lua` - Core utilities (wiki_root, ripgrep wrapper, validation functions)
-   - `davewiki/tags.lua` - Tag file management and tag operations
-   - `davewiki/markdown.lua` - Markdown link and file operations
-   - `davewiki/cmp.lua` - nvim-cmp integration
-   - `davewiki/telescope.lua` - Telescope integration for tag and heading search
-   - `davewiki/journal.lua` - Daily journal management and navigation
-    - `davewiki/view.lua` - Synthetic tag view generation
-    - `davewiki/test_util.lua` - Testing utilities (MockNotify)
- 
- 2. **Tests:**
-   - `tests/` - plenary.nvim test suite
-   - `test_root/` directory - sample notes and tags for testing
+  - `davewiki/init.lua` - Public interface, provides `setup()` function
+  - `davewiki/core.lua` - Core utilities (wiki_root, ripgrep wrapper,
+    validation functions)
+  - `davewiki/tags.lua` - Tag file management and tag operations
+  - `davewiki/markdown.lua` - Markdown link and file operations
+  - `davewiki/cmp.lua` - nvim-cmp integration
+  - `davewiki/telescope.lua` - Telescope integration for tag and heading
+    search
+  - `davewiki/journal.lua` - Daily journal management and navigation
+  - `davewiki/view.lua` - Synthetic tag view generation
+  - `davewiki/test_util.lua` - Testing utilities (MockNotify)
 
-4. **Scripts:**
-   - `scripts/` - Testing and development scripts
-   - `scripts/minimal-init.lua` - Minimal neovim config for testing (telescope and journal enabled)
-   - `scripts/davewiki2-init.lua` - Full neovim config with all plugin features enabled
+2. **Tests:**
+  - `tests/` - plenary.nvim test suite
+  - `test_root/` directory - sample notes and tags for testing
+
+3. **Scripts:**
+  - `scripts/` - Testing and development scripts
+  - `scripts/minimal-init.lua` - Minimal neovim config for testing
+    (telescope and journal enabled)
+  - `scripts/davewiki2-init.lua` - Full neovim config with all plugin
+    features enabled
 
 **Project Directory Structure:**
+
 ```
 lua/                     (lua modules)
 └── davewiki/
@@ -141,6 +168,7 @@ flake.nix                (nix build configuration)
 ```
 
 **Wiki Directory Structure (managed by plugin for users):**
+
 ```
 wiki_root/               (configurable, e.g., ~/.davewiki)
 ├── journals/            (daily journal files)
@@ -150,97 +178,132 @@ wiki_root/               (configurable, e.g., ~/.davewiki)
 ```
 
 **Data Flow:**
+
 - User takes notes in daily journals
 - Journal notes broken into "blocks" separated by `---`
 - Tags (`#tag-name`) in blocks associate those blocks with the tag
 - Tag associations discovered via on-demand ripgrep search (no persisted index)
 - Searching for tags finds all associated blocks/mentions across all files
 - Tag files act as anchor files for quick jump and back-link references
-- Non-journal notes stored in `notes/` directory (not managed by tag system but can mention tags)
+- Non-journal notes stored in `notes/` directory (not managed by tag system
+  but can mention tags)
 
 **Key Design Decisions:**
-1. Nix package for reproducible build with bundled standalone neovim instance - can still be installed as regular neovim plugin
+
+1. Nix package for reproducible build with bundled standalone neovim
+   instance - can still be installed as regular neovim plugin
 2. Journal-based approach inspired by Logseq
-3. Avoids Electron-based alternatives (Logseq, Obsidian), prefers vim keybindings and CLI
+3. Avoids Electron-based alternatives (Logseq, Obsidian), prefers vim
+   keybindings and CLI
 4. On-demand ripgrep search for tag associations (no persisted database/index)
 5. Block-based organization with `---` delimiters
 
 **Configuration Options:**
+
 - `wiki_root` - root directory for all notes
 - `telescope` - enable/configure telescope integration
 - `cmp` - enable/configure nvim-cmp integration
 - `journal` - enable/configure journal module
 
 **Existing Patterns:**
-- `davewiki.lua` exposes `setup()` function taking options table, returns initialized module
-- Prefer runtime import errors over startup crashes - load third-party modules (telescope, cmp) at setup time, not import time
+
+- `davewiki.lua` exposes `setup()` function taking options table, returns
+  initialized module
+- Prefer runtime import errors over startup crashes - load third-party
+  modules (telescope, cmp) at setup time, not import time
 
 ---
 
 ## 4. Development and Testing Process
 
 **Environment Setup:**
+
 1. **Nix users:** Run `nix develop` to enter development shell
 2. **Non-Nix users:** Manually install:
-   - neovim (0.9+)
-   - Required plugins and dependencies
-   - Add plugin to neovim's `rtp` setting
+  - neovim (0.9+)
+  - Required plugins and dependencies
+  - Add plugin to neovim's `rtp` setting
 
 **Build Process:**
+
 - `nix build .#nvim-test` - Build test neovim instance
 - `nix build .#davewiki` - Build davewiki package
 
 **Running Locally:**
+
 - `nix run .#nvim-test` - Run test neovim instance
 - `nix run .#davewiki` - Run davewiki application
-- Or enter dev shell: `nix develop` then use `nvim-test` and `davewiki` commands
+- Or enter dev shell: `nix develop` then use `nvim-test` and `davewiki`
+  commands
 
 **Testing:**
-- **Unit tests:** `nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c ...`
+
+- **Unit tests:**
+  `nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c ...`
 - **Integration tests:** Combined module/functionality testing
-- **Manual testing:** `nix run .#nvim-test` to open an interactive neovim instance with davewiki pre-configured using `scripts/minimal-init.lua`. The minimal init includes a working example of jump-to-tag functionality bound to `<CR>` in markdown files.
+- **Manual testing:** `nix run .#nvim-test` to open an interactive neovim
+  instance with davewiki pre-configured using `scripts/minimal-init.lua`. The
+  minimal init includes a working example of jump-to-tag functionality bound
+  to `<CR>` in markdown files.
 
 **Testing Commands:**
+
 - Always use minimal init: `-u scripts/minimal-init.lua`
 - Use `PlenaryBustedFile` to run a specific test file
 - Use `PlenaryBustedDirectory` to run all tests in a directory
 - Always end with `-c 'qa!'` to exit after tests complete
-- Example: `nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c 'PlenaryBustedFile tests/file_spec.lua' -c 'qa!'`
+- Example:
+  `nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c
+  'PlenaryBustedFile tests/file_spec.lua' -c 'qa!'`
 
 **Test Environment:**
+
 - Tests run against **real files** in `test_root/` directory - no mocking
 - Plugin only accesses files under `wiki_root`
 - Tests must use `test_root` and never access files outside `wiki_root`
 
 **Project Scripts Directory:**
+
 - `scripts/` - Testing and development scripts
-- `scripts/minimal-init.lua` - Minimal neovim config for testing and manual acceptance testing. Pre-configures davewiki with `test_root/` as wiki_root and includes a working example of `<CR>` keybinding for jump-to-tag functionality in markdown files.
+- `scripts/minimal-init.lua` - Minimal neovim config for testing and manual
+  acceptance testing. Pre-configures davewiki with `test_root/` as wiki_root
+  and includes a working example of `<CR>` keybinding for jump-to-tag
+  functionality in markdown files.
 
 **Debugging:**
+
 1. Run linters and type checker
-2. Run test code: `nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c "lua ..."`
+2. Run test code:
+   `nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c
+   "lua ..."`
 
 **Linting/Formatting/Type Checking:**
+
 - luacheck - Lua linter
 - stylua - Lua formatter
 - lua-language-server - Type checking (all code requires type annotations)
 
 **Code Quality Requirements:**
+
 - All Lua code must include type annotations
 - Type checking via lua-language-server must pass
 
 **Typical Workflows:**
+
 1. Write unit tests first (stub out to avoid errors, but tests should fail)
-2. Iterate on implementation until tests pass (testing against real files in `test_root/`, not mocks)
+2. Iterate on implementation until tests pass (testing against real files in
+   `test_root/`, not mocks)
 3. Verify all tests pass
 4. Run linter and type checker after every edit
 5. Test manually with `nix run`
 6. Run tests, linter, formatter, type checker before committing
 
 **Branching Strategy:**
+
 - Feature branches merged to main
 
 **Commit Message Format:**
+
 - Conventional Commits specification
 
 ---
@@ -248,35 +311,46 @@ wiki_root/               (configurable, e.g., ~/.davewiki)
 ## 5. Conventions and Rules
 
 **Code Organization:**
+
 - Follow neovim plugin conventions
 - Module structure as documented in Architecture Overview:
-- `lua/davewiki/init.lua` - Public interface with `setup()`
-   - `lua/davewiki/core.lua` - General utilities
-   - `lua/davewiki/cmp.lua` - nvim-cmp integration
-   - `lua/davewiki/telescope.lua` - Telescope integration
-   - `lua/davewiki/journal.lua` - Daily journal management and navigation
-   - `lua/davewiki/view.lua` - Synthetic tag view generation
+  - `lua/davewiki/init.lua` - Public interface with `setup()`
+  - `lua/davewiki/core.lua` - General utilities
+  - `lua/davewiki/cmp.lua` - nvim-cmp integration
+  - `lua/davewiki/telescope.lua` - Telescope integration
+  - `lua/davewiki/journal.lua` - Daily journal management and navigation
+  - `lua/davewiki/view.lua` - Synthetic tag view generation
 
 **Naming Conventions:**
+
 - Follow lua-language-server (LuaLS) naming conventions
 - Type annotations for all functions and modules
 
 **Documentation Standards:**
+
 - **README.md** - Project overview and usage
 - **PROJECT_PLAN.md** - Overall project plan document
 - **AGENTS.md** - Instructions for AI coding assistants
-- **Lua files:** Module and file-level docstrings, function docstrings with type annotations
+- **Lua files:** Module and file-level docstrings, function docstrings with
+  type annotations
 - **Nix files:** File-level descriptions and inline comments
-- **Tests:** Clear description of intent - what is being tested, why, and why this approach
+- **Tests:** Clear description of intent - what is being tested, why, and why
+  this approach
 
 **Code Review Practices:**
+
 - Peer review via pull requests
 
 **Antipatterns to Avoid:**
-1. **Over-mocking in unit tests** - Can produce passing tests for incorrect code. Use real `test_root/` files instead.
-2. **Requiring third-party modules at import time** - Raises unnecessary startup errors. Load third-party Lua just before use (at setup time, not import time).
+
+1. **Over-mocking in unit tests** - Can produce passing tests for incorrect
+   code. Use real `test_root/` files instead.
+2. **Requiring third-party modules at import time** - Raises unnecessary
+   startup errors. Load third-party Lua just before use (at setup time, not
+   import time).
 
 **File/Folder Organization:**
+
 ```
 davewiki/
 ├── lua/davewiki/        (lua modules)
@@ -294,32 +368,45 @@ davewiki/
 ## 6. Security Considerations
 
 **Authentication:**
-- Not applicable - this is a local neovim plugin with no authentication requirements
+
+- Not applicable - this is a local neovim plugin with no authentication
+  requirements
 
 **Authorization:**
+
 - Not applicable - operates within user's file system permissions
 
 **File Access Security:**
+
 - Plugin should **only** write or search files under the configured `wiki_root`
 - Must not access files outside the configured wiki root directory
 - Tests must use `test_root` and never access files outside `wiki_root`
 
 **User Input Handling:**
-1. **Tag names:** Must be validated against `#[A-Za-z0-9-_]+` (at word boundaries)
-2. **Shell command execution:** Use `vim.system` for all shell commands (preferred method)
-3. **Input escaping:** All user input (tag names, file paths, search queries) must be properly escaped or encoded when used in shell commands
+
+1. **Tag names:** Must be validated against `#[A-Za-z0-9-_]+` (at word
+   boundaries)
+2. **Shell command execution:** Use `vim.system` for all shell commands
+   (preferred method)
+3. **Input escaping:** All user input (tag names, file paths, search queries)
+   must be properly escaped or encoded when used in shell commands
 4. **Markdown hyperlinks:** Target paths must be URL-encoded
 
 **Known Vulnerabilities/Mitigations:**
-- **Arbitrary shell execution:** Injection into shell commands for searching, or via tag names/file paths
+
+- **Arbitrary shell execution:** Injection into shell commands for
+  searching, or via tag names/file paths
   - Mitigation: Use `vim.system` for all shell command execution
   - Mitigation: Validate tag names against strict regex pattern
-  - Mitigation: Always escape/encode user input before using in shell commands
+  - Mitigation: Always escape/encode user input before using in shell
+    commands
 
 **Security Review Requirements:**
+
 - Self-code review before commit (see Code Review Practices in Section 5)
 - Check for shell command injection vulnerabilities during review
 - Verify file access is limited to `wiki_root`
 
 **Secrets Management:**
+
 - Not applicable - no secrets or credentials handled by this plugin

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -99,6 +99,7 @@ Command-line neovim users who want a simple journal-based note-taking system.
 
 - luacheck - linting
 - stylua - Lua formatter
+- mdl - markdown linting
 - lua-language-server - type checking
 - git - version control
 - ripgrep - search utility
@@ -281,6 +282,7 @@ wiki_root/               (configurable, e.g., ~/.davewiki)
 
 - luacheck - Lua linter
 - stylua - Lua formatter
+- mdl - Markdown linter
 - lua-language-server - Type checking (all code requires type annotations)
 
 **Code Quality Requirements:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # davewiki
 
-A personal knowledge base system for neovim with journal-based note-taking, inspired by Logseq.
+A personal knowledge base system for neovim with journal-based note-taking,
+inspired by Logseq.
 
 ## What it does
 
@@ -8,21 +9,26 @@ A personal knowledge base system for neovim with journal-based note-taking, insp
 - Organizes notes using flat tags (`#tag-name`) with back-reference tracking
 - Provides quick search and navigation between tags, notes, and journals
 - Integrates with telescope.nvim for tag search and nvim-cmp for completion
-- Generates synthetic tag views that aggregate all references to a tag across the wiki
+- Generates synthetic tag views that aggregate all references to a tag across
+  the wiki
 
 ## How it works
 
 ### Wiki Root
 
-All your notes are stored in a configurable `wiki_root` directory (e.g., `~/davewiki`). All paths mentioned below are relative to this root directory.
+All your notes are stored in a configurable `wiki_root` directory
+(e.g., `~/davewiki`). All paths mentioned below are relative to this root
+directory.
 
 ### Journals
 
-Your daily notes live in `journals/`. Each journal file is a markdown document where you capture thoughts, ideas, and notes for that day.
+Your daily notes live in `journals/`. Each journal file is a markdown document
+where you capture thoughts, ideas, and notes for that day.
 
 ### Tags
 
-Tags (`#tag-name`) create connections between notes. When you add a tag to a block in your journal, that block becomes associated with the tag.
+Tags (`#tag-name`) create connections between notes. When you add a tag to a
+block in your journal, that block becomes associated with the tag.
 
 - Tags are flat (not hierarchical): `#my-tag`, `#another-tag`
 - Tag files live under `sources/` as anchor files
@@ -30,20 +36,32 @@ Tags (`#tag-name`) create connections between notes. When you add a tag to a blo
 
 ### Markdown Links
 
-Markdown links (`[text](path)`) provide navigation between notes and external resources.
+Markdown links (`[text](path)`) provide navigation between notes and external
+resources.
 
-- **Internal links**: Jump to other `.md` files within your wiki
-  - Absolute paths (recommended): `[notes](/notes/recipes.md)` - paths starting with `/` are resolved relative to `wiki_root`
-  - Relative paths: `[notes](./notes.md)` or `[notes](notes.md)` - resolved relative to the current file
-- **External URLs**: Open in your system's default browser
-  - `[website](https://example.com)`
-- **Security**: All paths are validated to stay within `wiki_root`
-- **Keybinding**: Press `<CR>` on any link to navigate (must be configured in your init.lua)
-- **Inserting links**: Use `:DavewikiInsertLink` to insert a link - it will automatically generate an absolute path
+**Internal links:**
+
+- Jump to other `.md` files within your wiki
+- Absolute paths (recommended): `[notes](/notes/recipes.md)` - paths starting
+  with `/` are resolved relative to `wiki_root`
+- Relative paths: `[notes](./notes.md)` or `[notes](notes.md)` - resolved
+  relative to the current file
+
+**External URLs:**
+
+- Open in your system's default browser: `[website](https://example.com)`
+
+**Security and navigation:**
+
+- All paths are validated to stay within `wiki_root`
+- Press `<CR>` on any link to navigate (must be configured in your init.lua)
+- Use `:DavewikiInsertLink` to insert a link - it will automatically generate
+  an absolute path
 
 ### Blocks
 
-Journals are organized into blocks separated by `---`. Each block can contain multiple tags. When you search for a tag, you find all blocks mentioning it.
+Journals are organized into blocks separated by `---`. Each block can contain
+multiple tags. When you search for a tag, you find all blocks mentioning it.
 
 ```
 ---
@@ -58,21 +76,28 @@ Another block with #vim tips.
 
 ### Other Notes
 
-Non-journal notes go in `notes/` and can mention tags, but aren't automatically indexed by the tagging system.
+Non-journal notes go in `notes/` and can mention tags, but aren't automatically
+indexed by the tagging system.
 
 ### Tag File Backlinks
 
-When you open a tag file (a markdown file in `sources/`), davewiki automatically searches your entire wiki for references to that tag and displays them in the quickfix window.
+When you open a tag file (a markdown file in `sources/`), davewiki
+automatically searches your entire wiki for references to that tag and displays
+them in the quickfix window.
 
 **Features:**
-- **Automatic display**: Quickfix window opens automatically when you enter a tag file
+
+- **Automatic display**: Quickfix window opens automatically when you enter a
+  tag file
 - **Navigation**: Press `<CR>` on any entry to jump to that reference
-- **Smart summary**: Each entry shows an 80-character preview with the tag visible
+- **Smart summary**: Each entry shows an 80-character preview with the tag
+  visible
 - **Auto-close**: Quickfix closes automatically when you leave the tag file
 - **Silent operation**: If no backlinks are found, nothing happens (no noise)
 - **Refresh**: Use `:e` to reload the tag file and refresh the backlink list
 
 **Configuration:**
+
 Enable/disable with the `show_tag_backlinks` option (enabled by default):
 
 ```lua
@@ -88,9 +113,12 @@ require('davewiki').setup({
 
 ### Tag Highlighting
 
-Tags (`#tag-name`) are automatically highlighted with a custom highlight group `DavewikiTag` when viewing markdown files within your wiki. This feature can be disabled by setting `highlight_tags = false` in your configuration.
+Tags (`#tag-name`) are automatically highlighted with a custom highlight group
+`DavewikiTag` when viewing markdown files within your wiki. This feature can be
+disabled by setting `highlight_tags = false` in your configuration.
 
 **Configuration:**
+
 ```lua
 require('davewiki').setup({
   wiki_root = "~/.davewiki",
@@ -99,12 +127,15 @@ require('davewiki').setup({
 ```
 
 **Default Style:**
+
 - Bright orange foreground (`#FF8C00`)
 - Dark charcoal background (`#2A2A2A`)
 - Underline
 
 **Customization:**
-You can override the highlight group in your Neovim configuration after loading the plugin:
+
+You can override the highlight group in your Neovim configuration after loading
+the plugin:
 
 ```lua
 -- Example: Custom colors for tags
@@ -125,43 +156,58 @@ vim.cmd("highlight DavewikiTag guifg=blue guibg=yellow gui=underline")
 
 ### Tag Views
 
-Synthetic tag views aggregate all references to a specific tag into a single buffer, providing a consolidated research view across your entire wiki.
+Synthetic tag views aggregate all references to a specific tag into a single
+buffer, providing a consolidated research view across your entire wiki.
 
 **Features:**
-- Generates a synthetic view file containing tag file content, journal blocks, and wiki references
+
+- Generates a synthetic view file containing tag file content, journal blocks,
+  and wiki references
 - Each section includes markdown links to source documents
 - View is created as an unsaved buffer - you can save it manually if desired
 - Automatically regenerates content when invoked for an existing view
 
 **View Content:**
+
 When you generate a tag view for `#cooking`, the buffer contains:
-1. **Tag File Content**: Full content of the `sources/cooking.md` tag file (or "NO TAG FILE" placeholder)
-2. **Journal Blocks**: Complete `---` separated blocks from journal files that mention `#cooking`
-3. **Wiki References**: Paragraphs from non-journal wiki files that mention `#cooking`
+
+1. **Tag File Content**: Full content of the `sources/cooking.md` tag file
+   (or "NO TAG FILE" placeholder)
+1. **Journal Blocks**: Complete `---` separated blocks from journal files that
+   mention `#cooking`
+1. **Wiki References**: Paragraphs from non-journal wiki files that mention
+   `#cooking`
 
 **Commands:**
 
 | Command | Description |
 |---------|-------------|
-| `:DavewikiGenerateView` | Open telescope picker to select a tag and generate its view |
+| `:DavewikiGenerateView` | Pick a tag and generate its view |
 | `:DavewikiGenerateViewFromCursor` | Generate view for the tag under cursor |
-| `:DavewikiGenerateViewFromTagFile` | Generate view for the current tag file (when editing a tag file) |
+| `:DavewikiGenerateViewFromTagFile` | Generate view for the current tag file |
 
 **Keymap Examples:**
+
 ```lua
 -- Generate view for tag under cursor
-vim.keymap.set('n', '<leader>wv', '<cmd>DavewikiGenerateViewFromCursor<CR>', { desc = "Generate tag view from cursor" })
+vim.keymap.set('n', '<leader>wv',
+  '<cmd>DavewikiGenerateViewFromCursor<CR>',
+  { desc = "Generate tag view from cursor" })
 
 -- Pick a tag and generate view
-vim.keymap.set('n', '<leader>wV', '<cmd>DavewikiGenerateView<CR>', { desc = "Pick tag and generate view" })
+vim.keymap.set('n', '<leader>wV', '<cmd>DavewikiGenerateView<CR>',
+  { desc = "Pick tag and generate view" })
 
 -- Generate view from current tag file
-vim.keymap.set('n', '<leader>wvf', '<cmd>DavewikiGenerateViewFromTagFile<CR>', { desc = "Generate view from current tag file" })
+vim.keymap.set('n', '<leader>wvf',
+  '<cmd>DavewikiGenerateViewFromTagFile<CR>',
+  { desc = "Generate view from current tag file" })
 ```
 
 ### Attachments
 
-Optional attachments (images, files) can be stored in `attachments/` within your wiki root.
+Optional attachments (images, files) can be stored in `attachments/` within your
+wiki root.
 
 ## Installation
 
@@ -183,13 +229,16 @@ require('lazy').setup({
 ### Dependencies
 
 **Required:**
+
 - `nvim-telescope/telescope.nvim` - search UI
 - `nvim-cmp` - tag completion
 
 **Development:**
+
 - `nvim-lua/plenary.nvim` - testing framework
 
 **Optional:**
+
 - `cmp-buffer` - buffer word completion
 - `telescope-fzf-native` - FZF sorter for telescope
 - `vim-markdown` - Markdown syntax and ftplugin
@@ -226,12 +275,12 @@ require('davewiki').setup({
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `wiki_root` | string | `~/davewiki` | Root directory for all notes (can also set `g:davewiki_wiki_root`) |
+| `wiki_root` | string | `~/davewiki` | Root directory for all notes |
 | `telescope.enabled` | boolean | `true` | Enable telescope integration |
 | `cmp.enabled` | boolean | `true` | Enable nvim-cmp integration |
 | `journal.enabled` | boolean | `true` | Enable journal module |
-| `show_tag_backlinks` | boolean | `true` | Enable automatic backlink display when opening tag files |
-| `highlight_tags` | boolean | `true` | Enable automatic tag syntax highlighting |
+| `show_tag_backlinks` | boolean | `true` | Enable automatic backlink display |
+| `highlight_tags` | boolean | `true` | Enable tag highlighting |
 
 ### Telescope Commands
 
@@ -240,15 +289,16 @@ When telescope integration is enabled, the following commands are available:
 | Command | Description |
 |---------|-------------|
 | `:DavewikiTags` | Open a telescope picker to search and navigate to tag files |
-| `:DavewikiTagReferences [tag_name]` | Search for tag references across the wiki |
-| `:DavewikiHeadings` | Search for level-1 headings across all markdown files |
-| `:DavewikiInsertLink` | Insert a markdown link to another wiki file using a telescope picker |
-| `:DavewikiJournals` | Open a telescope picker to browse and open journal files (requires journal module) |
-| `:DavewikiGenerateView` | Open telescope picker to select a tag and generate its synthetic view |
+| `:DavewikiTagReferences [tag]` | Search for tag references |
+| `:DavewikiHeadings` | Search for level-1 headings |
+| `:DavewikiInsertLink` | Insert a link using telescope |
+| `:DavewikiJournals` | Browse journal files (requires journal) |
+| `:DavewikiGenerateView` | Pick a tag and generate synthetic view |
 
 ### Journal Commands
 
-When the journal module is enabled, the following commands are available for daily journaling:
+When the journal module is enabled, the following commands are available for
+daily journaling:
 
 | Command | Description |
 |---------|-------------|
@@ -258,46 +308,56 @@ When the journal module is enabled, the following commands are available for dai
 | `:DavewikiJournalOpen` | Prompt for a date and open that journal |
 
 **Journal Features:**
+
 - Journals are stored as `YYYY-MM-DD.md` files in `${wiki_root}/journals/`
-- New journals automatically include YAML frontmatter with the date and sections for TASKS, AGENDA, and NOTES
+- New journals automatically include YAML frontmatter with the date and sections
+  for TASKS, AGENDA, and NOTES
 - The journals directory is created automatically if it doesn't exist
 - Multiple journals can be open simultaneously
 
 **Journal Template:**
+
 ```markdown
 ---
 date: 2026-03-26
 ---
 
-# 2026-03-26 - Wednesday
+## 2026-03-26 - Wednesday
 
-# TASKS
+## TASKS
 
-# AGENDA
+## AGENDA
 
-# NOTES
+## NOTES
 ```
 
 **Keymap Examples:**
 
 ```lua
 -- Open today's journal
-vim.keymap.set('n', '<leader>wjt', '<cmd>DavewikiJournalToday<CR>', { desc = "Open today's journal" })
+vim.keymap.set('n', '<leader>wjt', '<cmd>DavewikiJournalToday<CR>',
+  { desc = "Open today's journal" })
 
 -- Open yesterday's journal
-vim.keymap.set('n', '<leader>wjy', '<cmd>DavewikiJournalYesterday<CR>', { desc = "Open yesterday's journal" })
+vim.keymap.set('n', '<leader>wjy', '<cmd>DavewikiJournalYesterday<CR>',
+  { desc = "Open yesterday's journal" })
 
 -- Open tomorrow's journal
-vim.keymap.set('n', '<leader>wjT', '<cmd>DavewikiJournalTomorrow<CR>', { desc = "Open tomorrow's journal" })
+vim.keymap.set('n', '<leader>wjT', '<cmd>DavewikiJournalTomorrow<CR>',
+  { desc = "Open tomorrow's journal" })
 
 -- Open journal for specific date
-vim.keymap.set('n', '<leader>wjo', '<cmd>DavewikiJournalOpen<CR>', { desc = "Open journal for specific date" })
+vim.keymap.set('n', '<leader>wjo', '<cmd>DavewikiJournalOpen<CR>',
+  { desc = "Open journal for specific date" })
 ```
 
 **Smart Navigation:**
 
-The `:DavewikiJournalYesterday` and `:DavewikiJournalTomorrow` commands are context-aware:
-- If the current buffer is a journal file, they navigate relative to that journal's date
+The `:DavewikiJournalYesterday` and `:DavewikiJournalTomorrow` commands are
+context-aware:
+
+- If the current buffer is a journal file, they navigate relative to that
+  journal's date
 - Otherwise, they navigate relative to today's date
 
 **Usage Examples:**
@@ -359,7 +419,8 @@ require('cmp').setup({
 })
 ```
 
-When you type `#` followed by tag characters in a markdown file, davewiki will suggest matching tag names from your `sources/` directory.
+When you type `#` followed by tag characters in a markdown file, davewiki will
+suggest matching tag names from your `sources/` directory.
 
 ### Alternative Configuration
 
@@ -369,26 +430,31 @@ You can also set `wiki_root` via a vim global variable:
 let g:davewiki_wiki_root = '~/my-wiki'
 ```
 
-The priority for wiki_root is: setup option > `g:davewiki_wiki_root` > default `~/davewiki`
+The priority for wiki_root is: setup option > `g:davewiki_wiki_root` > default
+`~/davewiki`
 
 ## Development
 
 ### Manual Testing
 
-For manual acceptance testing, you can run an interactive neovim instance pre-configured with davewiki:
+For manual acceptance testing, you can run an interactive neovim instance
+pre-configured with davewiki:
 
 ```sh
 nix run .#nvim-test -- -u scripts/minimal-init.lua
 ```
 
 This opens neovim with the `scripts/minimal-init.lua` configuration, which:
+
 - Sets up davewiki with `./test_root` as the wiki root
 - Includes example keybindings for jump-to-tag functionality
 - Provides a minimal environment for testing features interactively
 
-You can test the tag navigation by opening any markdown file in `test_root/` and pressing `<CR>` on a tag (e.g., `#bengal`).
+You can test the tag navigation by opening any markdown file in `test_root/`
+and pressing `<CR>` on a tag (e.g., `#bengal`).
 
-You can test hyperlink navigation by pressing `<CR>` on a markdown link like `[notes](./notes.md)`or `[website](https://example.com)`.
+You can test hyperlink navigation by pressing `<CR>` on a markdown link like
+`[notes](./notes.md)` or `[website](https://example.com)`.
 
 For a fuller configuration with all features enabled and keymaps configured:
 
@@ -399,5 +465,6 @@ nix run .#nvim-test -- -u scripts/davewiki2-init.lua
 ### Running Tests
 
 ```sh
-nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c 'PlenaryBustedDirectory tests' -c 'qa!'
+nix run .#nvim-test -- -u scripts/minimal-init.lua --headless -c \
+  'PlenaryBustedDirectory tests' -c 'qa!'
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
           lua-language-server
           stylua
           gh
+          mdl
         ];
         neovimWrapped = pkgs.wrapNeovim pkgs.neovim-unwrapped {
           configure = {

--- a/lua/davewiki/cmp.lua
+++ b/lua/davewiki/cmp.lua
@@ -36,7 +36,7 @@ end
 --- Gets the trigger characters for this source
 ---@return string[]
 function wiki_tags_source:get_trigger_characters()
-    return { "#" }
+    return { "#[A-Za-z0-9-_]" }
 end
 
 --- Checks if this source is available in the current context

--- a/lua/davewiki/cmp.lua
+++ b/lua/davewiki/cmp.lua
@@ -4,6 +4,7 @@
 -- @version 1.0
 
 local cmp = {}
+local core = require("davewiki.core")
 local tags = require("davewiki.tags")
 
 ---@class DavewikiCmpConfig
@@ -28,7 +29,6 @@ local wiki_tags_source = {}
 ---@return table
 function wiki_tags_source.new()
     local self = setmetatable({}, { __index = wiki_tags_source })
-    local core = require("davewiki.core")
     self.wiki_root = core.wiki_root
     return self
 end
@@ -44,7 +44,14 @@ end
 function wiki_tags_source:is_available()
     local buf = vim.api.nvim_get_current_buf()
     local filetype = vim.bo[buf].filetype
-    return filetype == "markdown"
+    if filetype ~= "markdown" then
+        return false
+    end
+    local filepath = vim.api.nvim_buf_get_name(buf)
+    if filepath == "" then
+        return false
+    end
+    return core.is_path_within_wiki_root(filepath)
 end
 
 --- Performs completion for tag names

--- a/mdl_style.rb
+++ b/mdl_style.rb
@@ -1,0 +1,16 @@
+# markdownlint style file for davewiki2
+
+# MD029 - Ordered list item prefix
+# Allow either '1.' for all items OR incrementing numbers (both are valid markdown)
+rule 'MD029', :style => :one_or_ordered
+
+# MD007 - Unordered list indentation
+# Use 2-space indentation for lists
+rule 'MD007', :indent => 2
+
+# Exclude these rules
+exclude_rule 'MD013'  # Line length - many lines are intentionally long (commands, code, URLs)
+exclude_rule 'MD033'  # Inline HTML - sometimes needed for special formatting
+exclude_rule 'MD041'  # First line should be top level header - not applicable for AGENTS.md
+exclude_rule 'MD024'  # Multiple headers with same content - common in long documents
+exclude_rule 'MD034'  # Bare URL used - URLs render fine in most markdown parsers

--- a/tests/lua/davewiki/cmp_spec.lua
+++ b/tests/lua/davewiki/cmp_spec.lua
@@ -100,22 +100,31 @@ describe("davewiki.cmp wiki_tags source", function()
         end)
 
         describe("is_available", function()
-            it("should return true for markdown buffers", function()
-                local buf = vim.api.nvim_create_buf(false, true)
+            before_each(function()
+                core.setup({ wiki_root = test_root })
+            end)
+
+            it("should return true for markdown buffers within wiki_root", function()
+                local test_file = test_root .. "/cmp-test-file.md"
+                vim.fn.writefile({ "# Test" }, test_file)
+                local buf = vim.fn.bufadd(test_file)
+                vim.fn.bufload(buf)
                 vim.api.nvim_set_current_buf(buf)
                 vim.bo[buf].filetype = "markdown"
 
                 assert.is_true(source.is_available())
 
                 vim.api.nvim_buf_delete(buf, { force = true })
+                vim.fn.delete(test_file)
             end)
 
-            it("should return true for markdown buffers with different names", function()
+            it("should return false for markdown buffers outside wiki_root", function()
                 local buf = vim.api.nvim_create_buf(false, true)
+                vim.api.nvim_buf_set_name(buf, "/tmp/outside-wiki.md")
                 vim.api.nvim_set_current_buf(buf)
                 vim.bo[buf].filetype = "markdown"
 
-                assert.is_true(source.is_available())
+                assert.is_false(source.is_available())
 
                 vim.api.nvim_buf_delete(buf, { force = true })
             end)

--- a/tests/lua/davewiki/cmp_spec.lua
+++ b/tests/lua/davewiki/cmp_spec.lua
@@ -92,10 +92,11 @@ describe("davewiki.cmp wiki_tags source", function()
         end)
 
         describe("get_trigger_characters", function()
-            it("should return # as trigger character", function()
+            it("should return pattern requiring valid tag character after #", function()
                 local triggers = source.get_trigger_characters()
                 assert.is_table(triggers)
-                assert.is_true(vim.tbl_contains(triggers, "#"))
+                assert.are.equal(1, #triggers)
+                assert.are.equal("#[A-Za-z0-9-_]", triggers[1])
             end)
         end)
 


### PR DESCRIPTION
## Summary
- Restrict tag completion to only work within wiki_root
- Change trigger characters to require a valid tag character after "#"

## Changes
- Modified `is_available()` to check if current file is within wiki_root
- Updated `get_trigger_characters()` to return pattern that requires valid tag char
- Added tests for wiki_root boundary checking

## Testing
- Tag completion works for files within wiki_root
- Tag completion is disabled for files outside wiki_root