### PR TITLE
update, fix duplciate help tag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ result/
 
 # Test files created during test runs
 test_root/notes/relative-link-no-prefix.md
+node_modules

--- a/doc/tags
+++ b/doc/tags
@@ -1,5 +1,4 @@
 :DavewikiGenerateView	davewiki.txt	/*:DavewikiGenerateView*
-:DavewikiGenerateView	davewiki.txt	/*:DavewikiGenerateView*
 :DavewikiGenerateViewFromCursor	davewiki.txt	/*:DavewikiGenerateViewFromCursor*
 :DavewikiGenerateViewFromTagFile	davewiki.txt	/*:DavewikiGenerateViewFromTagFile*
 :DavewikiHeadings	davewiki.txt	/*:DavewikiHeadings*

--- a/flake.lock
+++ b/flake.lock
@@ -71,14 +71,15 @@
         "flake-utils": "flake-utils",
         "jail-nix": "jail-nix",
         "llm-agents": "llm-agents",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "skill-issues-src": "skill-issues-src"
       },
       "locked": {
-        "lastModified": 1776627540,
-        "narHash": "sha256-U++mSKR8YqRFpV/hLarBnN537cjX9hwZaMx7hOK1Xw8=",
+        "lastModified": 1776640455,
+        "narHash": "sha256-C989C+GnRt6JVHKdzaBFzfUhvaN0HS5d/FWYCwCigFk=",
         "owner": "dczmer",
         "repo": "dave-shield",
-        "rev": "46d4cba23449729cf0e0622dbfccb7eb9093ac52",
+        "rev": "264c59c327881cb5efa0692b2702b1eb13c90d7f",
         "type": "github"
       },
       "original": {
@@ -249,6 +250,22 @@
         "dave-shield": "dave-shield",
         "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_3"
+      }
+    },
+    "skill-issues-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776562922,
+        "narHash": "sha256-Wc1Bop6Huf2CZXnMiOsWcasJ2r6dlhHaxa238JwnbBk=",
+        "owner": "dczmer",
+        "repo": "skill-issues",
+        "rev": "7bcfa646dda2bcb54cad08a335e0e657a1d63fb8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dczmer",
+        "repo": "skill-issues",
+        "type": "github"
       }
     },
     "systems": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "davewiki2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@playwright/cli": "^0.1.8"
+      }
+    },
+    "node_modules/@playwright/cli": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.8.tgz",
+      "integrity": "sha512-z1oo8VewG3IevpiUd9+2OMa157yd9i9vQ+q3DUlYCk1Tb2oZ3mp2piyQbFH0j+msOQK5qLYSBgK6+wPlHZFXKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0-alpha-2026-04-14"
+      },
+      "bin": {
+        "playwright-cli": "playwright-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0-alpha-2026-04-14",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-2026-04-14.tgz",
+      "integrity": "sha512-wrYNgIOWpw/vaC4TpFHx9mVYF7kM6bYyRbStIHfxfqHDZvj1rNcYKSiIBNSUA9qm4bye4PvPEDSpe3RqjYFX6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0-alpha-2026-04-14"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0-alpha-2026-04-14",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-2026-04-14.tgz",
+      "integrity": "sha512-Wkuhxvhg7YnJXJo+UomP4XlOhdH+AL2QdzJyLuHzqKEIxFkKqtSKF5TTfLt5gyB0UhqEO6knMpr5hULo3W6OEw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@playwright/cli": "^0.1.8"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "davewiki2"
+version = "0.1.0"
+description = ""
+authors = [
+    {name = "Dave Czmer",email = "dczmer@gmail.com"}
+]
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+]
+
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Fix the duplicate help tag that was causing my neovim 0.12 flake to fail.
